### PR TITLE
Separated CMAKE_C_FLAGS from add_definitions using Unix to fix an err…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,8 @@ if(WIN32)
 
     add_library(uv ${SOURCES})
 else()
-    add_definitions(-g --std=gnu89 -pedantic -Wall -Wextra -Wno-unused-parameter -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g --std=gnu89 -pedantic -Wall -Wextra -Wno-unused-parameter")
+    add_definitions(-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64)
     include_directories(${LIBUVDIR}/src/unix)
     set(SOURCES ${SOURCES}
         ${LIBUVDIR}/include/uv-unix.h


### PR DESCRIPTION
…or when using Qt moc objects with OSX.