### PR TITLE
Update to v1.12.0 and fix Android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,11 +170,9 @@ else()
     if (${CMAKE_SYSTEM_NAME} MATCHES "Android")
         set (SOURCES ${SOURCES}
             ${LIBUVDIR}/include/android-ifaddrs.h
-            ${LIBUVDIR}/include/pthread-fixes.h
-            #${LIBUVDIR}/include/pthread-barrier.h   ## since 1.10 `fixes` renamed to `barrier`
+            ${LIBUVDIR}/include/pthread-barrier.h
             ${LIBUVDIR}/src/unix/android-ifaddrs.c
-            ${LIBUVDIR}/src/unix/pthread-fixes.c
-            #${LIBUVDIR}/src/unix/pthread-barrier.c  ## since 1.10 `fixes` renamed to `barrier`
+            ${LIBUVDIR}/src/unix/pthread-barrier.c
             )
     endif()
 


### PR DESCRIPTION
These changes update libuv to v1.12.0 - I actually don't recall anymore why I updated, I think we had some build issues with Android and I tried to update to fix them.

One change which was definately necessary for android was already marked in the CMake file, I removed the lines which are deprecated for new libuv versions.